### PR TITLE
优化：多目标匹配时，当最佳匹配得分小于设定得分时，退出GetNextMaxLoc循环，提升检测速度。

### DIFF
--- a/MatchTool/MatchToolDlg.cpp
+++ b/MatchTool/MatchToolDlg.cpp
@@ -866,8 +866,8 @@ BOOL CMatchToolDlg::Match ()
 			for (int j = 0; j < m_iMaxPos + MATCH_CANDIDATE_NUM - 1; j++)
 			{
 				ptMaxLoc = GetNextMaxLoc (matResult, ptMaxLoc, pTemplData->vecPyramid[iTopLayer].size (), dValue, m_dMaxOverlap, blockMax);
-				if (dMaxVal < vecLayerScore[iTopLayer])
-					continue;
+				if (dValue < vecLayerScore[iTopLayer])
+					break;
 				vecMatchParameter.push_back (s_MatchParameter (Point2f (ptMaxLoc.x - fTranslationX, ptMaxLoc.y - fTranslationY), dValue, vecAngles[i]));
 			}
 		}
@@ -880,8 +880,8 @@ BOOL CMatchToolDlg::Match ()
 			for (int j = 0; j < m_iMaxPos + MATCH_CANDIDATE_NUM - 1; j++)
 			{
 				ptMaxLoc = GetNextMaxLoc (matResult, ptMaxLoc, pTemplData->vecPyramid[iTopLayer].size (), dValue, m_dMaxOverlap);
-				if (dMaxVal < vecLayerScore[iTopLayer])
-					continue;
+				if (dValue < vecLayerScore[iTopLayer])
+					break;
 				vecMatchParameter.push_back (s_MatchParameter (Point2f (ptMaxLoc.x - fTranslationX, ptMaxLoc.y - fTranslationY), dValue, vecAngles[i]));
 			}
 		}


### PR DESCRIPTION
优化：多目标匹配时，当最佳匹配得分小于设定得分时，退出GetNextMaxLoc循环，提升检测速度。
测试条件：当测试图像中的模板数量小于设置的最大查找数量时，将产生多余的耗时