### PR TITLE
Remove Clock calls

### DIFF
--- a/MatchTool/MatchToolDlg.cpp
+++ b/MatchTool/MatchToolDlg.cpp
@@ -1276,7 +1276,6 @@ void CMatchToolDlg::MatchTemplate (cv::Mat& matSrc, s_TemplData* pTemplData, cv:
 {
 	if (m_ckSIMD.GetCheck () && bUseSIMD)
 	{
-		double d1 = clock ();
 		//From ImageShop
 		matResult.create (matSrc.rows - pTemplData->vecPyramid[iLayer].rows + 1,
 			matSrc.cols - pTemplData->vecPyramid[iLayer].cols + 1, CV_32FC1);
@@ -1338,8 +1337,6 @@ void CMatchToolDlg::CCOEFF_Denominator (cv::Mat& matSrc, s_TemplData* pTemplData
 
 	Mat sum, sqsum;
 	integral (matSrc, sum, sqsum, CV_64F);
-
-	double d2 = clock ();
 
 	q0 = (double*)sqsum.data;
 	q1 = q0 + pTemplData->vecPyramid[iLayer].cols;


### PR DESCRIPTION
Remove Calls to clock to remove slow down after high number of matches

In my case these calls lead to a exponential slow down of the match calls. 
At first it is not really noticeable, but after 30k matches the slow down is significant (~20ms at start, ~200ms at 30k)